### PR TITLE
[FIX] Workaround for Linux icons + small fix

### DIFF
--- a/src/Main.py
+++ b/src/Main.py
@@ -17,6 +17,8 @@ from utils.Database import (
 from utils.Export import export_to_csv
 from utils.Visualization import plot_bar_chart, plot_pie_chart, plot_line_chart
 
+from sys import platform as sys_platform
+
 
 class BudgetTrackerApp:
     PAGES = [
@@ -33,7 +35,10 @@ class BudgetTrackerApp:
         self.root.title("Budget Tracker")
         self.root.geometry("1000x600")
 
-        self.root.iconbitmap("Icon.ico")
+        # Icon loading on Linux gives error. This fixes it for now.
+        if sys_platform == "win32" or sys_platform == "cygwin":
+            self.root.iconbitmap("Icon.ico")
+
         ctk.set_appearance_mode("dark")
         ctk.set_default_color_theme("dark-blue")
 

--- a/src/utils/Export.py
+++ b/src/utils/Export.py
@@ -1,6 +1,6 @@
 import csv
 from datetime import datetime
-from src.utils.Database import get_account_id, fetch_data, fetch_total
+from utils.Database import get_account_id, fetch_data, fetch_total
 
 # Constants for CSV headers
 TRANSACTION_HEADERS = ["Category", "Amount", "Currency", "Date"]


### PR DESCRIPTION
## Pull Request Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code where applicable, especially in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or errors.
- [ ] I have added tests that prove my fix or feature works.
- [x] New and existing unit tests pass locally with my changes.

## Description

This works around a crash when running the application where it can't load the provided `Icon.ico` file in Linux. I'm still investigating how to fix this but for now this will avoid the crashes.

Also, this commit fixes a small bug introduced in commit b685f58a9496f9a639eadb72ecd4a7a26998f827 (PR #36) that causes a crash when trying to import some utilities from `utils` by referencing the `src` directory (it hasn't been set up with an `__init__.py`).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [ ] Unit tests
- [x] Manual testing
- [ ] Other (please specify)

## Screenshots (if applicable):
